### PR TITLE
Fix Docker for tracingData

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM openjdk:8-jre
 
 RUN mkdir -p /srv/webknossos-datastore \
-  && groupadd -r webknossos \
-  && useradd -r -g webknossos webknossos \
+  && groupadd -g 1000 -r webknossos \
+  && useradd -u 1000 -r -g webknossos webknossos \
   && cd /srv/webknossos-datastore \
   && mkdir disk \
+  && mkdir tracingData \
   && chown -R webknossos .
 
 WORKDIR /srv/webknossos-datastore
 
-VOLUME /srv/webknossos-datastore/binaryData /srv/webknossos-datastore/userBinaryData /srv/webknossos-datastore/tracingData
+VOLUME /srv/webknossos-datastore/binaryData /srv/webknossos-datastore/tracingData
 
 COPY target/universal/stage .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jre
 
-RUN apk --no-cache add bash \
-  && mkdir -p /srv/webknossos-datastore \
-  && adduser -H -D webknossos webknossos \
+RUN mkdir -p /srv/webknossos-datastore \
+  && groupadd -r webknossos \
+  && useradd -r -g webknossos webknossos \
   && cd /srv/webknossos-datastore \
   && mkdir disk \
   && chown -R webknossos .
 
 WORKDIR /srv/webknossos-datastore
 
-VOLUME /srv/webknossos-datastore/binaryData /srv/webknossos-datastore/userBinaryData 
+VOLUME /srv/webknossos-datastore/binaryData /srv/webknossos-datastore/userBinaryData /srv/webknossos-datastore/tracingData
 
 COPY target/universal/stage .
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ binaryData/ # Needs to be writable by docker user (uid=1000 gid=1000)
                 ...
             settings.json
         ...
-userBinaryData/ # Needs to be writable by docker user (uid=1000 gid=1000)
+tracingData/ # Needs to be writable by docker user (uid=1000 gid=1000)
 ```
 
 ### Configure datastore
@@ -50,7 +50,7 @@ braingames.binary.cacheMaxSize = 1000 # in entries (each cache entry is 2 MB)
 docker create \
   --name webknossos-datastore \
   -v /path/to/binaryData:/srv/webknossos-datastore/binaryData \
-  -v /path/to/userBinaryData:/srv/webknossos-datastore/userBinaryData \
+  -v /path/to/tracingData:/srv/webknossos-datastore/tracingData \
   -v /path/to/docker.conf:/srv/webknossos-datastore/conf/docker.conf \
   -p 9090:9090 \
   scalableminds/webknossos-datastore:master \


### PR DESCRIPTION
* The new RocksDB resides in a new folder `tracingData` which needs to be mounted in Docker installations.
* Also, RocksDB requires libc which is why we can't use the alpine base image.